### PR TITLE
Fix fish warning by disowning background process

### DIFF
--- a/fig.fish
+++ b/fig.fish
@@ -39,11 +39,11 @@ if [ -d /Applications/Fig.app -o -d ~/Applications/Fig.app ] && command -v fig 1
         end
 
         function fig_precmd --on-event fish_prompt
-            fig bg:prompt $fish_pid (tty) &
+            fig bg:prompt $fish_pid (tty) &; disown
         end
 
         function fig_preexec --on-event fish_preexec
-            fig bg:exec $fish_pid (tty) &
+            fig bg:exec $fish_pid (tty) &; disown
         end
 
         set FIG_SHELL_VAR 1

--- a/tools/install_and_upgrade.sh
+++ b/tools/install_and_upgrade.sh
@@ -79,8 +79,7 @@ install_fig() {
     cd ~/.fig/autocomplete
 
     {
-        curl https://codeload.github.com/withfig/autocomplete/tar.gz/master | \
-        tar -xz --strip-components=2 autocomplete-master/specs
+        curl -s "https://waitlist.withfig.com/specs?version=latest" | tar -xz --strip-components=1 specs
         
     } || {
         error "pulling latest autocomplete files failed"


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Fix 
**What is the current behavior? (You can also link to an open issue here)**
When exiting a fish process the user receives a warning that fig bg:exec is running in background.
**What is the new behavior (if this is a feature change)?**
No warning!
**Additional info:**
Also contains the new /specs download URL