### PR TITLE
Fix link to fig-apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The config directory is structured like so:
 </tr>
 <tr>
     <td>apps/</td>
-    <td>installed Fig apps. See <a href="https://github.com/withfig/autocomplete"> withfig/fig-apps</a> </td>
+    <td>installed Fig apps. See <a href="https://github.com/withfig/fig-apps"> withfig/fig-apps</a> </td>
 </tr>
 <tr>
     <td>team/</td>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update

**What is the current behavior? (You can also link to an open issue here)**
When clicking on withfig/fig-apps it actually takes to autocomplete repo, but it should take to fig-apps repo

**What is the new behavior (if this is a feature change)?**
Take the user to the withfig/fig-apps repository page

**Additional info:**