### PR TITLE
[Experimental] Improved SSH Support

### DIFF
--- a/fig.fish
+++ b/fig.fish
@@ -1,0 +1,30 @@
+if [ -d /Applications/Fig.app -o -d ~/Applications/Fig.app ] \
+  && command -v fig 1>/dev/null 2>/dev/null
+
+  if [ -t 1 ] && [ -z "$FIG_ENV_VAR" ] || [ -n "$TMUX" ]
+    # Gives fig context for cwd in each window.
+    fig bg:init $fish_pid (tty)
+
+    # Run aliases shell script
+    if [ -s ~/.fig/user/aliases/_myaliases.sh ]
+      bash ~/.fig/user/aliases/*.sh
+    end
+
+    # Check for prompts or onboarding.
+    if [ -s ~/.fig/tools/prompts.sh ]
+      bash ~/.fig/tools/prompts.sh
+    end
+
+    export TTY=(tty)
+    export FIG_ENV_VAR=1
+  end
+
+  if [ -z "$FIG_SHELL_VAR" ]
+    # Prevents weird interaction where setting the title with ANSI escape
+    # sequence triggers prompt redraw.
+    fig settings autocomplete.addStatusToTerminalTitle false &
+    fig bg:exec $fish_pid (tty) &
+
+    source ~/.fig/shell/post.fish
+  end
+end

--- a/fig.sh
+++ b/fig.sh
@@ -18,11 +18,7 @@ if ([[ -d /Applications/Fig.app ]] || [[ -d ~/Applications/Fig.app ]]) \
     [[ -s ~/.fig/tools/prompts.sh ]] && source ~/.fig/tools/prompts.sh
   fi
 
-  # We use a shell variable to make sure this doesn't load twice
-  if [[ -z "${FIG_SHELL_VAR}" ]]; then
-    source ~/.fig/shell/post.sh
-    FIG_SHELL_VAR=1
-  fi
+  source ~/.fig/shell/post.sh
 
   # todo: Add a check to confirm "add-zle-hook-widget" facility exists
   # Not included in fig.zsh, because should be run last

--- a/shell/post.bash
+++ b/shell/post.bash
@@ -12,7 +12,7 @@ function fig_osc { printf "\033]697;"; printf $@; printf "\007"; }
 function __fig_preexec() {
   __fig_ret_value="$?"
 
-  $(fig bg:exec $$ $(tty) &)
+  $(command -v fig && fig bg:exec $$ $(tty) &)
 
   fig_osc PreExec
 
@@ -38,7 +38,7 @@ function __fig_preexec() {
 function __fig_prompt () {
   __fig_ret_value="$?"
 
-  $(fig bg:prompt $$ $TTY &)
+  $(command -v fig && fig bg:prompt $$ $TTY &)
 
   # Work around bug in CentOS 7.2 where preexec doesn't run if you press ^C
   # while entering a command.

--- a/shell/post.bash
+++ b/shell/post.bash
@@ -12,7 +12,7 @@ function fig_osc { printf "\033]697;"; printf $@; printf "\007"; }
 function __fig_preexec() {
   __fig_ret_value="$?"
 
-  $(command -v fig && fig bg:exec $$ $(tty) &)
+  $(command -v fig > /dev/null 2>&1 && fig bg:exec $$ $(tty) &)
 
   fig_osc PreExec
 
@@ -38,7 +38,7 @@ function __fig_preexec() {
 function __fig_prompt () {
   __fig_ret_value="$?"
 
-  $(command -v fig && fig bg:prompt $$ $TTY &)
+  $(command -v fig > /dev/null 2>&1 && fig bg:prompt $$ $TTY &)
 
   # Work around bug in CentOS 7.2 where preexec doesn't run if you press ^C
   # while entering a command.

--- a/shell/post.fish
+++ b/shell/post.fish
@@ -1,95 +1,68 @@
-if [ -d /Applications/Fig.app -o -d ~/Applications/Fig.app ] \
-  && command -v fig 1>/dev/null 2>/dev/null
-
-  if [ -t 1 ] && [ -z "$FIG_ENV_VAR" ] || [ -n "$TMUX" ]
-    # Gives fig context for cwd in each window.
-    fig bg:init $fish_pid (tty)
-
-    # Run aliases shell script
-    if [ -s ~/.fig/user/aliases/_myaliases.sh ]
-      bash ~/.fig/user/aliases/*.sh
-    end
-
-    # Check for prompts or onboarding.
-    if [ -s ~/.fig/tools/prompts.sh ]
-      bash ~/.fig/tools/prompts.sh
-    end
-
-    export TTY=(tty)
-    export FIG_ENV_VAR=1
+if [ -z "$FIG_SHELL_VAR" ]
+  function fig_keybuffer --on-signal SIGUSR1
+    echo fig bg:fish-keybuffer "$TERM_SESSION_ID" $FIG_INTEGRATION_VERSION 0 (commandline -C) \"(commandline)\" \
+      | base64 \
+      | /usr/bin/nc -U /tmp/fig.socket
   end
 
-  if [ -z "$FIG_SHELL_VAR" ]
-    function fig_keybuffer --on-signal SIGUSR1
-      echo fig bg:fish-keybuffer "$TERM_SESSION_ID" $FIG_INTEGRATION_VERSION 0 (commandline -C) \"(commandline)\" \
-        | base64 \
-        | /usr/bin/nc -U /tmp/fig.socket
+  function fig_osc; printf "\033]697;"; printf $argv; printf "\007"; end
+  function fig_copy_fn; functions -e $argv[2]; functions -c $argv[1] $argv[2]; end
+  function fig_fn_defined; test (functions $argv[1] | grep -vE '^ *(#|function |end$|$)' | wc -l | xargs) != 0; end
+
+  function fig_wrap_prompt
+    set -l last_status $status
+    fig_osc StartPrompt
+
+    sh -c "exit $last_status"
+    printf "%b" (string join "\n" $argv)
+    fig_osc EndPrompt
+
+    sh -c "exit $last_status"
+  end
+
+  function fig_preexec --on-event fish_preexec
+    command -v fig && fig bg:exec $fish_pid (tty) &; disown
+    fig_osc PreExec
+
+    if fig_fn_defined fig_user_mode_prompt
+      fig_copy_fn fig_user_mode_prompt fish_mode_prompt
     end
 
-    function fig_osc; printf "\033]697;"; printf $argv; printf "\007"; end
-    function fig_copy_fn; functions -e $argv[2]; functions -c $argv[1] $argv[2]; end
-    function fig_fn_defined; test (functions $argv[1] | grep -vE '^ *(#|function |end$|$)' | wc -l | xargs) != 0; end
-
-    function fig_wrap_prompt
-      set -l last_status $status
-      fig_osc StartPrompt
-
-      sh -c "exit $last_status"
-      printf "%b" (string join "\n" $argv)
-      fig_osc EndPrompt
-
-      sh -c "exit $last_status"
+    if fig_fn_defined fig_user_right_prompt
+      fig_copy_fn fig_user_right_prompt fish_right_prompt
     end
 
-    function fig_preexec --on-event fish_preexec
-      fig bg:exec $fish_pid (tty) &; disown
-      fig_osc PreExec
+    fig_copy_fn fig_user_prompt fish_prompt
 
-      if fig_fn_defined fig_user_mode_prompt
-        fig_copy_fn fig_user_mode_prompt fish_mode_prompt
-      end
-
-      if fig_fn_defined fig_user_right_prompt
-        fig_copy_fn fig_user_right_prompt fish_right_prompt
-      end
-
-      fig_copy_fn fig_user_prompt fish_prompt
-
-      set fig_has_set_prompt 0
-    end
-
-    function fig_precmd --on-event fish_prompt
-      fig bg:prompt $fish_pid (tty) &; disown
-
-      if [ $fig_has_set_prompt = 1 ]
-        fig_preexec
-      end
-
-      fig_osc "Dir=%s" $PWD
-      fig_osc "Shell=fish" $PWD
-
-      if fig_fn_defined fish_mode_prompt
-        fig_copy_fn fish_mode_prompt fig_user_mode_prompt
-        function fish_mode_prompt; fig_wrap_prompt (fig_user_mode_prompt); end
-      end
-
-      if fig_fn_defined fish_right_prompt
-        fig_copy_fn fish_right_prompt fig_user_right_prompt
-        function fish_right_prompt; fig_wrap_prompt (fig_user_right_prompt); end
-      end
-
-      fig_copy_fn fish_prompt fig_user_prompt
-      function fish_prompt; fig_wrap_prompt (fig_user_prompt); fig_osc NewCmd; end
-
-      set fig_has_set_prompt 1
-    end
-
-    set FIG_SHELL_VAR 1
     set fig_has_set_prompt 0
-
-    # Prevents weird interaction where setting the title with ANSI escape
-    # sequence triggers prompt redraw.
-    fig settings autocomplete.addStatusToTerminalTitle false &
-    fig bg:exec $fish_pid (tty) &
   end
+
+  function fig_precmd --on-event fish_prompt
+    command -v fig && fig bg:prompt $fish_pid (tty) &; disown
+
+    if [ $fig_has_set_prompt = 1 ]
+      fig_preexec
+    end
+
+    fig_osc "Dir=%s" $PWD
+    fig_osc "Shell=fish" $PWD
+
+    if fig_fn_defined fish_mode_prompt
+      fig_copy_fn fish_mode_prompt fig_user_mode_prompt
+      function fish_mode_prompt; fig_wrap_prompt (fig_user_mode_prompt); end
+    end
+
+    if fig_fn_defined fish_right_prompt
+      fig_copy_fn fish_right_prompt fig_user_right_prompt
+      function fish_right_prompt; fig_wrap_prompt (fig_user_right_prompt); end
+    end
+
+    fig_copy_fn fish_prompt fig_user_prompt
+    function fish_prompt; fig_wrap_prompt (fig_user_prompt); fig_osc NewCmd; end
+
+    set fig_has_set_prompt 1
+  end
+
+  set FIG_SHELL_VAR 1
+  set fig_has_set_prompt 0
 end

--- a/shell/post.fish
+++ b/shell/post.fish
@@ -21,7 +21,7 @@ if [ -z "$FIG_SHELL_VAR" ]
   end
 
   function fig_preexec --on-event fish_preexec
-    command -v fig && fig bg:exec $fish_pid (tty) &; disown
+    command -v fig > /dev/null 2>&1 && fig bg:exec $fish_pid (tty) &; disown
     fig_osc PreExec
 
     if fig_fn_defined fig_user_mode_prompt
@@ -38,7 +38,7 @@ if [ -z "$FIG_SHELL_VAR" ]
   end
 
   function fig_precmd --on-event fish_prompt
-    command -v fig && fig bg:prompt $fish_pid (tty) &; disown
+    command -v fig > /dev/null 2>&1 && fig bg:prompt $fish_pid (tty) &; disown
 
     if [ $fig_has_set_prompt = 1 ]
       fig_preexec

--- a/shell/post.sh
+++ b/shell/post.sh
@@ -1,19 +1,23 @@
-if [[ -n "$BASH" ]]; then
-  source ~/.fig/shell/post.bash
-elif [[ -n "$ZSH_NAME" ]]; then
-  source ~/.fig/shell/post.zsh
-else
-  # Fallback to naive method, exposed alteration of prompt variables if in unrecognized shell.
-  if [ -z "${FIG_PTY_SHELL_VAR}" ]; then
-    FIG_SHELL="\001\033]697;Shell=unknown\007\002"
-    FIG_START_PROMPT="${FIG_SHELL}\001\033]697;StartPrompt\007\002"
-    FIG_END_PROMPT="\001\033]697;EndPrompt\007\002"
-    FIG_NEW_CMD="\001\033]697;NewCmd\007\002"
+# We use a shell variable to make sure this doesn't load twice
+if [[ -z "${FIG_SHELL_VAR}" ]]; then
+  if [[ -n "$BASH" ]]; then
+    source ~/.fig/shell/post.bash
+  elif [[ -n "$ZSH_NAME" ]]; then
+    source ~/.fig/shell/post.zsh
+  else
+    # Fallback to naive method, exposed alteration of prompt variables if in unrecognized shell.
+    if [ -z "${FIG_PTY_SHELL_VAR}" ]; then
+      FIG_SHELL="\001\033]697;Shell=unknown\007\002"
+      FIG_START_PROMPT="${FIG_SHELL}\001\033]697;StartPrompt\007\002"
+      FIG_END_PROMPT="\001\033]697;EndPrompt\007\002"
+      FIG_NEW_CMD="\001\033]697;NewCmd\007\002"
 
-    PS1="${FIG_START_PROMPT}${PS1}${FIG_END_PROMPT}${FIG_NEW_CMD}"
-    PS2="${FIG_START_PROMPT}${PS2}${FIG_END_PROMPT}"
-    PS3="${FIG_START_PROMPT}${PS3}${FIG_END_PROMPT}${FIG_NEW_CMD}"
+      PS1="${FIG_START_PROMPT}${PS1}${FIG_END_PROMPT}${FIG_NEW_CMD}"
+      PS2="${FIG_START_PROMPT}${PS2}${FIG_END_PROMPT}"
+      PS3="${FIG_START_PROMPT}${PS3}${FIG_END_PROMPT}${FIG_NEW_CMD}"
 
-    FIG_PTY_SHELL_VAR=1
+      FIG_PTY_SHELL_VAR=1
+    fi
   fi
+  FIG_SHELL_VAR=1
 fi

--- a/shell/post.zsh
+++ b/shell/post.zsh
@@ -6,7 +6,7 @@ FIG_HAS_ZSH_PTY_HOOKS=1
 FIG_HAS_SET_PROMPT=0
 
 fig_preexec() {
-  fig bg:exec $$ $TTY &!
+  command -v fig && fig bg:exec $$ $TTY &!
 
   # Restore user defined prompt before executing.
   PS1="$FIG_USER_PS1"
@@ -19,7 +19,8 @@ fig_preexec() {
 }
 
 fig_precmd() {
-  fig bg:prompt $$ $TTY &!
+  echo hi
+  command -v fig && fig bg:prompt $$ $TTY &!
 
   if [ $FIG_HAS_SET_PROMPT -eq 1 ]; then
     # ^C pressed while entering command, call preexec manually to clear fig prompts.

--- a/shell/post.zsh
+++ b/shell/post.zsh
@@ -6,7 +6,7 @@ FIG_HAS_ZSH_PTY_HOOKS=1
 FIG_HAS_SET_PROMPT=0
 
 fig_preexec() {
-  command -v fig && fig bg:exec $$ $TTY &!
+  command -v fig > /dev/null 2>&1 && fig bg:exec $$ $TTY &!
 
   # Restore user defined prompt before executing.
   PS1="$FIG_USER_PS1"
@@ -19,8 +19,7 @@ fig_preexec() {
 }
 
 fig_precmd() {
-  echo hi
-  command -v fig && fig bg:prompt $$ $TTY &!
+  command -v fig > /dev/null 2>&1 && fig bg:prompt $$ $TTY &!
 
   if [ $FIG_HAS_SET_PROMPT -eq 1 ]; then
     # ^C pressed while entering command, call preexec manually to clear fig prompts.

--- a/shell/remote.sh
+++ b/shell/remote.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# We use a shell variable to make sure this doesn't load twice
+if [[ -z "${FIG_SHELL_VAR}" ]]; then
+  source ~/.fig/shell/post.sh
+  FIG_SHELL_VAR=1
+fi

--- a/ssh
+++ b/ssh
@@ -2,4 +2,4 @@ ControlPath ~/.ssh/%C
 ControlMaster auto
 ControlPersist 1
 PermitLocalCommand yes
-LocalCommand ~/.fig/bin/fig bg:ssh ~/.ssh/%C & ~/.fig/tools/install_remote.sh ~/.ssh/%C %r %h &
+LocalCommand fig bg:ssh ~/.ssh/%C & ~/.fig/tools/install_remote.sh ~/.ssh/%C %r %h &

--- a/ssh
+++ b/ssh
@@ -2,4 +2,4 @@ ControlPath ~/.ssh/%C
 ControlMaster auto
 ControlPersist 1
 PermitLocalCommand yes
-LocalCommand fig bg:ssh ~/.ssh/%C &
+LocalCommand ~/.fig/bin/fig bg:ssh ~/.ssh/%C & ~/.fig/tools/install_remote.sh ~/.ssh/%C %r %h &

--- a/tools/install_and_upgrade.sh
+++ b/tools/install_and_upgrade.sh
@@ -96,38 +96,12 @@ install_fig() {
   fi
 }
 
-fig_source() {
-  printf "#### FIG ENV VARIABLES ####\n"
-  printf "[ -s ~/.fig/$1 ] && source ~/.fig/$1\n"
-  printf "#### END FIG ENV VARIABLES ####\n"
-}
-
-fig_append() {
-  # Appends line to a config file to source file from the ~/.fig directory.
-  # Usage: fig_append fig.sh path/to/rc
-  # Don't append to files that don't exist to avoid creating file and
-  # changing shell behavior.
-  if [ -f "$2" ] && ! grep -q "source ~/.fig/$1" "$2"; then
-    echo "$(fig_source $1)" >> "$2"
-  fi
-}
-
-fig_prepend() {
-  # Prepends line to a config file to source file from the ~/.fig directory.
-  # Usage: fig_prepend fig_pre.sh path/to/rc
-  # Don't prepend to files that don't exist to avoid creating file and
-  # changing shell behavior.
-  if [ -f "$2" ] && ! grep -q "source ~/.fig/$1" "$2"; then
-    echo -e "$(fig_source $1)\n$(cat $2)" > $2
-  fi
-}
-
 # Add the fig.sh to your profiles so it can be sourced on new terminal window load
 append_to_profiles() {
   # Replace old sourcing in profiles.
   for rc in .profile .zprofile .bash_profile; do
     if [[ -e "${HOME}/${rc}" ]]; then
-      sed -i '' 's/~\/.fig\/exports\/env.sh/~\/.fig\/fig.sh/g' "~/.${rc}" 2> /dev/null
+      sed -i '' 's/~\/.fig\/exports\/env.sh/~\/.fig\/fig.sh/g' "${HOME}/${rc}" 2> /dev/null
     fi
   done
   
@@ -137,11 +111,11 @@ append_to_profiles() {
   done
 
   # Handle fish separately.
-  mkdir -p ~/.config/fish/conf.d
+  mkdir -p "${HOME}/.config/fish/conf.d"
 
   # Use 00_/99_ prefix to load script earlier/later in fish startup.
   ln -sf ~/.fig/shell/pre.fish ~/.config/fish/conf.d/00_fig_pre.fish
-  ln -sf ~/.fig/shell/post.fish ~/.config/fish/conf.d/99_fig_post.fish
+  ln -sf ~/.fig/fig.fish ~/.config/fish/conf.d/99_fig_post.fish
 
   # Remove deprecated fish config file.
   if [[ -f -~/.config/fish/conf.d/fig.fish ]]; then
@@ -182,7 +156,8 @@ install_tmux_integration() {
 }
 
 install_fig
-append_to_profiles
+source ~/.fig/tools/install_helpers.sh
+append_to_profiles "${HOME}"
 setup_onboarding
 install_tmux_integration
 echo success

--- a/tools/install_helpers.sh
+++ b/tools/install_helpers.sh
@@ -1,0 +1,26 @@
+fig_source() {
+  printf "#### FIG ENV VARIABLES ####\n"
+  printf "[ -s ~/.fig/$1 ] && source ~/.fig/$1\n"
+  printf "#### END FIG ENV VARIABLES ####\n"
+}
+
+fig_append() {
+  # Appends line to a config file to source file from the ~/.fig directory.
+  # Usage: fig_append fig.sh path/to/rc
+  # Don't append to files that don't exist to avoid creating file and
+  # changing shell behavior.
+  if [ -f "$2" ] && ! grep -q "source ~/.fig/$1" "$2"; then
+    echo "$(fig_source $1)" >> "$2"
+  fi
+}
+
+fig_prepend() {
+  # Prepends line to a config file to source file from the ~/.fig directory.
+  # Usage: fig_prepend fig_pre.sh path/to/rc
+  # Don't prepend to files that don't exist to avoid creating file and
+  # changing shell behavior.
+  if [ -f "$2" ] && ! grep -q "source ~/.fig/$1" "$2"; then
+    echo -e "$(fig_source $1)\n$(cat $2)" > $2
+  fi
+}
+

--- a/tools/install_remote.sh
+++ b/tools/install_remote.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+CONTROL_PATH="$1"
+USER="$2"
+HOST="$3"
+
+REMOTE="${USER}@${HOST}"
+REMOTE_HOME="${REMOTE}:~/"
+TMP_HOME=/tmp/fig_remote_install/
+RCS=(.zshrc .bashrc .profile .zprofile .bash_profile)
+
+source ~/.fig/tools/install_helpers.sh
+
+copy () {
+  scp -r -o "ControlPath=${CONTROL_PATH}" "$@" > /dev/null 2>&1
+}
+
+remotecmd () {
+  ssh -o "ControlPath=${CONTROL_PATH}" "${REMOTE}" "$@" > /dev/null 2>&1
+}
+
+rm -rf "${TMP_HOME}"
+mkdir -p "${TMP_HOME}"
+cp "${HOME}/.fig/shell/post.sh" "${TMP_HOME}fig.sh"
+cp "${HOME}/.fig/shell/post.fish" "${TMP_HOME}fig.fish"
+
+remotecmd "mkdir -p ~/.fig"
+copy "${HOME}/.fig/shell" "${TMP_HOME}fig.sh" "${REMOTE_HOME}.fig/"
+
+# Copy all files we update during install.
+# TODO(sean) optimize and slim down number of files here to bare min for efficiency.
+copy "${RCS[@]/#/$REMOTE_HOME}" "${TMP_HOME}"
+
+for rc in "${RCS[@]}"; do
+  fig_append fig.sh "${TMP_HOME}${rc}"
+done
+
+copy "${RCS[@]/#/$TMP_HOME}" "${REMOTE_HOME}"
+
+remotecmd "mkdir -p ~/.config/fish/conf.d"
+copy "${TMP_HOME}fig.fish" "${REMOTE_HOME}.config/fish/conf.d/99_fig_post.fish"


### PR DESCRIPTION
Adds ssh functionality that copies shell configs to remote machine to easily take fig with you when you ssh

Still left todo:
- Support nested connections by copying over ssh install script and ssh config in addition to base fig config.
- Pass remote tty/hostname info back through fig pty module
- Add prompt and disable options to make this feature transparent and configurable. Will default to disabled.