### PR TITLE
Pass login shell to figterm and clean up env variables

### DIFF
--- a/fig.sh
+++ b/fig.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
-if ([[ -d /Applications/Fig.app ]] || [[ -d ~/Applications/Fig.app ]]) \
+if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
   && [[ ! "${TERMINAL_EMULATOR}" = JetBrains-JediTerm ]] \
-  && command -v fig 1> /dev/null 2> /dev/null; then
+  && command -v fig 2>&1 1>/dev/null \
+  && [[ -t 1 ]]; then
 
-  if [[ -t 1 ]] && ([[ -z "${FIG_ENV_VAR}" ]] \
-            || [[ -n "${TMUX}" ]] \
-            || [[ "${TERM_PROGRAM}" = vscode ]]); then
+  if [[ -z "${FIG_ENV_VAR}" || -n "${TMUX}" || "${TERM_PROGRAM}" = vscode ]]; then
     export FIG_ENV_VAR=1
 
     # Gives fig context for cwd in each window

--- a/shell/post.bash
+++ b/shell/post.bash
@@ -47,13 +47,13 @@ function __fig_prompt () {
 
   # If FIG_USER_PSx is undefined or PSx changed by user, update FIG_USER_PSx.
   if [[ -z "${FIG_USER_PS1+x}" || "${PS1}" != "${FIG_LAST_PS1}" ]]; then
-    export FIG_USER_PS1="${PS1}"
+    FIG_USER_PS1="${PS1}"
   fi
   if [[ -z "${FIG_USER_PS2+x}" || "${PS2}" != "${FIG_LAST_PS2}" ]]; then
-    export FIG_USER_PS2="${PS2}"
+    FIG_USER_PS2="${PS2}"
   fi
   if [[ -z "${FIG_USER_PS3+x}" || "${PS3}" != "${FIG_LAST_PS3}" ]]; then
-    export FIG_USER_PS3="${PS3}"
+    FIG_USER_PS3="${PS3}"
   fi
 
   fig_osc "Dir=%s" "${PWD}"
@@ -72,9 +72,9 @@ function __fig_prompt () {
   export PS2="${START_PROMPT}${FIG_USER_PS2}${END_PROMPT}"
   export PS3="${START_PROMPT}${FIG_USER_PS3}${END_PROMPT}${NEW_CMD}"
 
-  export FIG_LAST_PS1="${PS1}"
-  export FIG_LAST_PS2="${PS2}"
-  export FIG_LAST_PS3="${PS3}"
+  FIG_LAST_PS1="${PS1}"
+  FIG_LAST_PS2="${PS2}"
+  FIG_LAST_PS3="${PS3}"
 }
 
 # trap DEBUG -> preexec -> command -> PROMPT_COMMAND -> prompt shown.

--- a/shell/pre.fish
+++ b/shell/pre.fish
@@ -5,24 +5,25 @@ if [ -d /Applications/Fig.app -o -d ~/Applications/Fig.app ] \
   && command -v fig 1>/dev/null 2>/dev/null \
   && [ -t 1 ]
 
-  if [ -z "$FIG_PRE_ENV_VAR" ] || [ -n "$TMUX" ]
-    # Generated automatically by iTerm and Terminal But needs to be
-    # explicitly set for VSCode and Hyper. This variable is inherited when
-    # new ttys are created using tmux and must be explictly overwritten.
-    if [ -z "$TERM_SESSION_ID" ] || [ -n "$TMUX" ]
-      export TERM_SESSION_ID=(uuidgen)
-    end
-    export FIG_INTEGRATION_VERSION=4
-    export FIG_PRE_ENV_VAR=1
+  # Generated automatically by iTerm and Terminal But needs to be
+  # explicitly set for VSCode and Hyper. This variable is inherited when
+  # new ttys are created using tmux and must be explictly overwritten.
+  if [ -z "$TERM_SESSION_ID" ] || [ -n "$TMUX" ] || [ "$TERM_PROGRAM" = vscode ]
+    export TERM_SESSION_ID=(uuidgen)
   end
+  export FIG_INTEGRATION_VERSION=4
 
   if command -v figterm 1>/dev/null 2>/dev/null
     if [ -z "$FIG_TERM" ] || [ -z "$FIG_TERM_TMUX" -a -n "$TMUX" ]
       set FIG_SHELL (~/.fig/bin/fig_get_shell)
+      set FIG_IS_LOGIN_SHELL 0
+      if status --is-login
+        set FIG_IS_LOGIN_SHELL 1
+      end
       set FIG_TERM_NAME (basename "$FIG_SHELL")" (figterm)"
       set FIG_SHELL_PATH "$HOME/.fig/bin/$FIG_TERM_NAME"
       cp ~/.fig/bin/figterm "$FIG_SHELL_PATH"
-      exec bash -c "FIG_SHELL=$FIG_SHELL exec -a \"$FIG_TERM_NAME\" \"$FIG_SHELL_PATH\""
+      exec bash -c "FIG_SHELL=$FIG_SHELL FIG_IS_LOGIN_SHELL=$FIG_IS_LOGIN_SHELL exec -a \"$FIG_TERM_NAME\" \"$FIG_SHELL_PATH\""
     end
   end
 end

--- a/shell/pre.sh
+++ b/shell/pre.sh
@@ -10,30 +10,33 @@ pathadd ~/.fig/bin
 
 if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
   && [[ "${TERMINAL_EMULATOR}" != JetBrains-JediTerm ]] \
-  && command -v fig 1> /dev/null 2> /dev/null \
+  && command -v fig 2>&1 1>/dev/null \
   && [[ -t 1 ]]; then
 
-  if [[ -z "${FIG_PRE_ENV_VAR}" || -n "${TMUX}" || "${TERM_PROGRAM}" = vscode ]]; then
-    # Generated automatically by iTerm and Terminal, but needs to be
-    # explicitly set for VSCode and Hyper. This variable is inherited when
-    # new ttys are created using Tmux of VSCode and must be explictly
-    # overwritten.
-    if ([[ -z "${TERM_SESSION_ID}" || -n "${TMUX}" || "${TERM_PROGRAM}" = vscode ]]); then 
-      export TERM_SESSION_ID="$(uuidgen)"
-    fi
-    export FIG_INTEGRATION_VERSION=4
-    export FIG_PRE_ENV_VAR=1
+  # Generated automatically by iTerm and Terminal, but needs to be
+  # explicitly set for VSCode and Hyper. This variable is inherited when
+  # new ttys are created using Tmux of VSCode and must be explictly
+  # overwritten.
+  if [[ -z "${TERM_SESSION_ID}" || -n "${TMUX}" || "${TERM_PROGRAM}" = vscode ]]; then
+    export TERM_SESSION_ID="$(uuidgen)"
   fi
+  export FIG_INTEGRATION_VERSION=4
 
   # Only launch figterm if current session is not already inside PTY and command exists
-  if [[ -z "${FIG_PTY}" ]] &&command -v ~/.fig/bin/figterm 1> /dev/null 2> /dev/null; then
+  if [[ -z "${FIG_PTY}" ]] && command -v ~/.fig/bin/figterm 2>&1 1>/dev/null; then
     if [[ -z "${FIG_TERM}" || (-z "${FIG_TERM_TMUX}" && -n "${TMUX}") ]]; then
       # Pty module sets FIG_TERM or FIG_TERM_TMUX to avoid running twice. 
       FIG_SHELL=$(~/.fig/bin/fig_get_shell)
+      FIG_IS_LOGIN_SHELL=0
+
+      if ([[ -n "$BASH" ]] && shopt -q login_shell) \
+        || ([[ -n "$ZSH_NAME" && -o login ]]); then
+        FIG_IS_LOGIN_SHELL=1
+      fi
       FIG_TERM_NAME="${FIG_SHELL} (figterm)"
       FIG_SHELL_PATH="${HOME}/.fig/bin/$(basename "${FIG_SHELL}") (figterm)"
       cp ~/.fig/bin/figterm "${FIG_SHELL_PATH}"
-      FIG_SHELL="${FIG_SHELL}" exec -a "${FIG_TERM_NAME}" "${FIG_SHELL_PATH}"
+      FIG_SHELL="${FIG_SHELL}" FIG_IS_LOGIN_SHELL="${FIG_IS_LOGIN_SHELL}" exec -a "${FIG_TERM_NAME}" "${FIG_SHELL_PATH}"
     fi
   fi
 fi


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes issue where shell created by figterm does not mirror login attribute of parent shell.

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**