### PR TITLE
Add default values for width/height in settings app

### DIFF
--- a/tools/all-settings.json
+++ b/tools/all-settings.json
@@ -97,13 +97,15 @@
     "settingName": "autocomplete.height",
     "title": "Autocomplete window height",
     "description": "Set the maximum height of the autocomplete window in pixels",
-    "type": "number"
+    "type": "number",
+    "default": "380"
   },
   {
     "settingName": "autocomplete.width",
     "title": "Autocomplete window width",
     "description": "Set the maximum width of the autocomplete window in pixels",
-    "type": "number"
+    "type": "number",
+    "default": "250"
   },
   {
     "settingName": "autocomplete.fuzzySearch",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
feature
**What is the current behavior? (You can also link to an open issue here)**
User wants to increase the width & height setting but because there is no default value, they start at 100 for both for example. They then have to keep guessing until they get what they want.
**What is the new behavior (if this is a feature change)?**
Provide default values for the user so they have more control. If they want to increase height slightly, they can just increase it by 20% quickly.
**Additional info:**
- Addresses https://github.com/withfig/fig/issues/272