### PR TITLE
Changed details for disable command to fix settings app

### DIFF
--- a/tools/all-settings.json
+++ b/tools/all-settings.json
@@ -75,7 +75,7 @@
     "title": "Disable Fig for specific CLI tools",
     "description": "A JSON array of CLI tools that Fig should NOT autocomplete on.",
     "type": "multiselect",
-    "details": "e.g. [\"git\",\"npm\"]"
+    "details": "e.g. git,npm"
   },
   {
     "settingName": "autocomplete.enter",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
Fig currently autocompletes for all commands, even commands that are listed under the "Disable Fig for specific CLI Tools" setting due to an incorrect format.

**What is the new behavior (if this is a feature change)?**
Shows the user the correct format to disable autocomplete for certain CLI tools. Fig autocomplete should not show up for CLI tools that are added to this setting: "Disable Fig for specific CLI Tools"

**Additional info:**
- Addresses https://github.com/withfig/fig/issues/285