### PR TITLE
Prefer cat to echo for unknown input

### DIFF
--- a/tools/install_and_upgrade.sh
+++ b/tools/install_and_upgrade.sh
@@ -121,7 +121,7 @@ fig_prepend() {
   # Don't prepend to files that don't exist to avoid creating file and
   # changing shell behavior.
   if [ -f "$2" ] && ! grep -q "source ~/.fig/$1" "$2"; then
-    echo -e "$(fig_source $1)\n$(cat $2)" > $2
+    echo "$(fig_source $1)" | cat - "$2" > "/tmp/fig_prepend" && mv "/tmp/fig_prepend" "$2"
   fi
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug fix

**What is the current behavior? (You can also link to an open issue here)**

Certain escape characters will end bash input, which can lead to only parts of user's dotfiles being kept when we prepend.

**What is the new behavior (if this is a feature change)?**

Replace echo with cat to ensure no parts of user's dotfiles are lost

**Additional info:**