### PR TITLE
Add newline to ensure Fig isn't appended to existing lines

### DIFF
--- a/tools/install_and_upgrade.sh
+++ b/tools/install_and_upgrade.sh
@@ -102,7 +102,7 @@ install_fig() {
 }
 
 fig_source() {
-  printf "#### FIG ENV VARIABLES ####\n"
+  printf "\n#### FIG ENV VARIABLES ####\n"
   printf "[ -s ~/.fig/$1 ] && source ~/.fig/$1\n"
   printf "#### END FIG ENV VARIABLES ####\n"
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
Re: https://github.com/withfig/fig/issues/343
The sourcing line will sometimes be appended to a non-empty line, causing unpredictable bugs

**What is the new behavior (if this is a feature change)?**
Always add a newline before the ENV VAR lines to each config file

**Additional info:**