### PR TITLE
Delete figterm artifacts

### DIFF
--- a/shell/pre.sh
+++ b/shell/pre.sh
@@ -35,6 +35,9 @@ if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
       fi
       FIG_TERM_NAME="${FIG_SHELL} (figterm)"
       FIG_SHELL_PATH="${HOME}/.fig/bin/$(basename "${FIG_SHELL}") (figterm)"
+
+      # fix for arch related crash in zsh on M1
+      rm "${FIG_SHELL_PATH}" 2> /dev/null
       cp ~/.fig/bin/figterm "${FIG_SHELL_PATH}"
       # Get initial text.
       INITIAL_TEXT=""

--- a/tools/install_and_upgrade.sh
+++ b/tools/install_and_upgrade.sh
@@ -45,6 +45,8 @@ install_fig() {
     rm "${HOME}/.fig/bin/zsh (figterm)"
     rm "${HOME}/.fig/bin/bash (figterm)"
     rm "${HOME}/.fig/bin/fish (figterm)"
+    rm "${HOME}/.fig/bin/figterm"
+    
     curl "https://codeload.github.com/withfig/config/tar.gz/${FIG_TAG}" \
       | tar -xz --strip-components=1 \
       || (

--- a/tools/install_and_upgrade.sh
+++ b/tools/install_and_upgrade.sh
@@ -40,6 +40,11 @@ install_fig() {
     cd ~/.fig
   else
     cd ~/.fig
+
+    # Remove previous artifacts to prevent crashes
+    rm "${HOME}/.fig/bin/zsh (figterm)"
+    rm "${HOME}/.fig/bin/bash (figterm)"
+    rm "${HOME}/.fig/bin/fish (figterm)"
     curl "https://codeload.github.com/withfig/config/tar.gz/${FIG_TAG}" \
       | tar -xz --strip-components=1 \
       || (


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bugfix
**What is the current behavior? (You can also link to an open issue here)**
Sometimes on update, `figterm` will consistently crash when launching new terminal sessions.
**What is the new behavior (if this is a feature change)?**
Delete old `$SHELL (figterm)` binaries because this seems to resolve the issue (TBD whether or not this is true)
**Additional info:**