### PR TITLE
feat: add autocomplete.fontFamily setting

### DIFF
--- a/tools/all-settings.json
+++ b/tools/all-settings.json
@@ -34,6 +34,12 @@
     "category": "Autocomplete"
   },
   {
+    "settingName": "autocomplete.fontFamily",
+    "title": "Font Family",
+    "description": "Change the font of autocomplete",
+    "type": "text"
+  },
+  {
     "settingName": "autocomplete.sortMethod",
     "title": "Sort Suggestions",
     "description": "Specifies how Fig should sort suggestions.",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature

**What is the current behavior? (You can also link to an open issue here)**
There is no way of customizing the fontFamily of the autocomplete window


**What is the new behavior (if this is a feature change)?**

**Additional info:**