### PR TITLE
Remove binary artifacts on install and get rid of legacy workaround

### DIFF
--- a/shell/pre.fish
+++ b/shell/pre.fish
@@ -23,8 +23,6 @@ if [ -d /Applications/Fig.app -o -d ~/Applications/Fig.app ] \
       set FIG_TERM_NAME (basename "$FIG_SHELL")" (figterm)"
       set FIG_SHELL_PATH "$HOME/.fig/bin/$FIG_TERM_NAME"
 
-      # fix for arch related crash in zsh on M1
-      rm "FIG_SHELL_PATH" 2> /dev/null
       cp -p ~/.fig/bin/figterm "$FIG_SHELL_PATH"
       
       exec bash -c "FIG_SHELL=$FIG_SHELL FIG_IS_LOGIN_SHELL=$FIG_IS_LOGIN_SHELL exec -a \"$FIG_TERM_NAME\" \"$FIG_SHELL_PATH\""

--- a/shell/pre.sh
+++ b/shell/pre.sh
@@ -36,8 +36,6 @@ if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
       FIG_TERM_NAME="${FIG_SHELL} (figterm)"
       FIG_SHELL_PATH="${HOME}/.fig/bin/$(basename "${FIG_SHELL}") (figterm)"
 
-      # fix for arch related crash in zsh on M1
-      rm "${FIG_SHELL_PATH}" 2> /dev/null
       cp -p ~/.fig/bin/figterm "${FIG_SHELL_PATH}"
       # Get initial text.
       INITIAL_TEXT=""

--- a/tools/install_and_upgrade.sh
+++ b/tools/install_and_upgrade.sh
@@ -49,8 +49,14 @@ install_fig() {
   # Create fig dir an cd into it
   mkdir -p ~/.fig
 
+  # delete binary artifacts to ensure ad-hoc code signature works for arm64 binaries on M1
+  rm ~/.fig/bin/figterm
+  rm ~/.fig/bin/fig_callback
+  rm ~/.fig/bin/fig_get_shell
+  rm ~/.fig/bin/*'(figterm)'
+
   if [[ "${FIG_TAG}" == "local" ]]; then
-    cp -r "$PWD"/* ~/.fig
+    cp -R "$PWD"/* ~/.fig
     cd ~/.fig
   else
     cd ~/.fig


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bugfix. Solves [#386](https://github.com/withfig/fig/issues/386) and still removes binary artifacts.
