### PR TITLE
Add workaround for istrip bug

### DIFF
--- a/shell/post.zsh
+++ b/shell/post.zsh
@@ -47,6 +47,11 @@ fig_precmd() {
   PS3="%{$START_PROMPT%}$PS3%{$END_PROMPT$NEW_CMD%}"
   RPS1="%{$START_PROMPT%}$RPS1%{$END_PROMPT%}"
   FIG_HAS_SET_PROMPT=1
+
+  # Temporary workaround for bug where istrip is activated (for unknown reasons).
+  # When istrip is turned on, input characters are strippped to seven bits.
+  # This causes zle insertion to stop due to our reliance on `fig_insert` being bound to a unicode character 
+  command stty -istrip
 }
 
 add-zsh-hook precmd fig_precmd


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Hotfix
**What is the current behavior? (You can also link to an open issue here)**
When the `stty` setting `istrip` is enabled, inserting text in `zsh` using `fig` will result in`'` or an `(` character instead of the intended text.

This is because we do text insertion in ZSH by binding a `fig_insert` function to the `◧` character. 

**What is the new behavior (if this is a feature change)?**
We reset the `istrip` setting to off on every line using the zsh `pre_prompt` hook.
