### PR TITLE
Prevent Fig from starting when ran from Warp.

### DIFF
--- a/fig.sh
+++ b/fig.sh
@@ -10,7 +10,7 @@ pathadd ~/.fig/bin
 
 if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
   && [[ ! "${TERMINAL_EMULATOR}" = JetBrains-JediTerm ]] \
-  && [[ ! "${TERMINAL_EMULATOR}" = WarpTerminal ]] \
+  && [[ ! "${TERM_PROGRAM}" = WarpTerminal ]] \
   && command -v fig 2>&1 1>/dev/null; then
 
   if [[ -t 1 ]] && [[ -z "${FIG_ENV_VAR}" || -n "${TMUX}" || "${TERM_PROGRAM}" = vscode ]]; then

--- a/fig.sh
+++ b/fig.sh
@@ -10,7 +10,6 @@ pathadd ~/.fig/bin
 
 if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
   && [[ ! "${TERMINAL_EMULATOR}" = JetBrains-JediTerm ]] \
-  && [[ ! "${TERM_PROGRAM}" = WarpTerminal ]] \
   && command -v fig 2>&1 1>/dev/null; then
 
   if [[ -t 1 ]] && [[ -z "${FIG_ENV_VAR}" || -n "${TMUX}" || "${TERM_PROGRAM}" = vscode ]]; then

--- a/fig.sh
+++ b/fig.sh
@@ -10,6 +10,7 @@ pathadd ~/.fig/bin
 
 if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
   && [[ ! "${TERMINAL_EMULATOR}" = JetBrains-JediTerm ]] \
+  && [[ ! "${TERMINAL_EMULATOR}" = WarpTerminal ]] \
   && command -v fig 2>&1 1>/dev/null; then
 
   if [[ -t 1 ]] && [[ -z "${FIG_ENV_VAR}" || -n "${TMUX}" || "${TERM_PROGRAM}" = vscode ]]; then

--- a/shell/pre.sh
+++ b/shell/pre.sh
@@ -10,6 +10,7 @@ pathadd ~/.fig/bin
 
 if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
   && [[ "${TERMINAL_EMULATOR}" != JetBrains-JediTerm ]] \
+  && [[ ! "${TERM_PROGRAM}" = WarpTerminal ]] \
   && command -v fig 2>&1 1>/dev/null \
   && [[ -t 1 ]]; then
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix / Feature

**What is the current behavior? (You can also link to an open issue here)**
Fig won't run within Warp.

**What is the new behavior (if this is a feature change)?**
This adds cross compatibility to ensure that Fig continues to function except from within Warp.

**Additional info:**
Self explanatory.