### PR TITLE
Prevent error message "stdin is not a terminal"

### DIFF
--- a/shell/post.zsh
+++ b/shell/post.zsh
@@ -48,10 +48,10 @@ fig_precmd() {
   RPS1="%{$START_PROMPT%}$RPS1%{$END_PROMPT%}"
   FIG_HAS_SET_PROMPT=1
 
-  # Temporary workaround for bug where istrip is activated (for unknown reasons).
+  # Temporary workaround for bug where istrip is activated when running brew install.
   # When istrip is turned on, input characters are strippped to seven bits.
-  # This causes zle insertion to stop due to our reliance on `fig_insert` being bound to a unicode character 
-  command stty -istrip
+  # This causes zle insertion to stop due to our reliance on `fig_insert` being bound to a unicode character
+  [[ -t 1 ]] && command stty -istrip
 }
 
 add-zsh-hook precmd fig_precmd


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**