### PR TITLE
Update issues link to point to new issues template

### DIFF
--- a/tools/cli/issue.sh
+++ b/tools/cli/issue.sh
@@ -7,4 +7,4 @@
 #  Copyright © 2021 Matt Schrage. All rights reserved.
 
 echo "→ Opening Github..."
-open https://github.com/withfig/fig/issues/new
+open "https://github.com/withfig/fig/issues/new?assignees=&labels=NEED_TO_LABEL&template=1_main_issue_template.yml"


### PR DESCRIPTION
Using new issues template in withfig/fig. Link for `fig issue` was never updated to reflect new template.