### PR TITLE
CLI tool to email dotfiles

### DIFF
--- a/tools/cli/debug.sh
+++ b/tools/cli/debug.sh
@@ -66,7 +66,7 @@ case "$1" in
     env
     ;;
   "dotfiles")
-    echo "Not implemented yet..."
+  "$HOME"/.fig/tools/cli/email_dotfiles.sh
     ;;
   # "shell-startup")
 

--- a/tools/cli/email_dotfiles.sh
+++ b/tools/cli/email_dotfiles.sh
@@ -1,3 +1,32 @@
 #!/usr/bin/env bash
 
-curl -X POST --data "$(defaults read com.mschrage.fig | grep userEmail)" --data FILEBREAK --data-binary @"$HOME/.profile" --data FILEBREAK --data-binary @"$HOME/.zprofile" --data FILEBREAK --data-binary @"$HOME/.bash_profile" --data FILEBREAK --data-binary @"$HOME/.bashrc" --data FILEBREAK --data-binary @"$HOME/.zshrc" https://waitlist.withfig.com/dotfiles
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+
+echo -e "We will be sending the following files (if they exist) to hello@fig.io and will CC you:\n"
+echo -e '  -' ~/.profile
+echo -e '  -' ~/.zprofile
+echo -e '  -' ~/.bash_profile
+echo -e '  -' ~/.bashrc
+echo -e '  -' ~/.zshrc
+echo -e '\n'
+
+function abort {
+	echo -e "${RED}Aborting..."
+	exit 1
+}
+
+read -rp "Continue? (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || abort
+
+echo -e '\n'
+
+curl -X POST--data "$(defaults read com.mschrage.fig | grep userEmail)" \
+	--data FILEBREAK --data-binary @"$HOME/.profile" \
+	--data FILEBREAK --data-binary @"$HOME/.zprofile" \
+	--data FILEBREAK --data-binary @"$HOME/.bash_profile" \
+	--data FILEBREAK --data-binary @"$HOME/.bashrc" \
+	--data FILEBREAK --data-binary @"$HOME/.zshrc" \
+	--data FILEBREAK --data-binary @"$HOME/.config/fish/config.fish" \
+	https://waitlist.withfig.com/dotfiles 2>/dev/null
+
+echo -e "\n${GREEN}Dotfiles emailed!"

--- a/tools/cli/email_dotfiles.sh
+++ b/tools/cli/email_dotfiles.sh
@@ -9,6 +9,7 @@ echo -e '  -' ~/.zprofile
 echo -e '  -' ~/.bash_profile
 echo -e '  -' ~/.bashrc
 echo -e '  -' ~/.zshrc
+echo -e '  -' ~/.config/fish/config.fish
 echo -e '\n'
 
 function abort {
@@ -20,7 +21,7 @@ read -rp "Continue? (Y/N): " confirm && [[ $confirm == [yY] || $confirm == [yY][
 
 echo -e '\n'
 
-curl -X POST--data "$(defaults read com.mschrage.fig | grep userEmail)" \
+curl -X POST --data "$(defaults read com.mschrage.fig | grep userEmail)" \
 	--data FILEBREAK --data-binary @"$HOME/.profile" \
 	--data FILEBREAK --data-binary @"$HOME/.zprofile" \
 	--data FILEBREAK --data-binary @"$HOME/.bash_profile" \

--- a/tools/cli/email_dotfiles.sh
+++ b/tools/cli/email_dotfiles.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+curl -X POST --data "$(defaults read com.mschrage.fig | grep userEmail)" --data FILEBREAK --data-binary @"$HOME/.profile" --data FILEBREAK --data-binary @"$HOME/.zprofile" --data FILEBREAK --data-binary @"$HOME/.bash_profile" --data FILEBREAK --data-binary @"$HOME/.bashrc" --data FILEBREAK --data-binary @"$HOME/.zshrc" https://waitlist.withfig.com/dotfiles


### PR DESCRIPTION
Basic curl command to email all zsh and bash dotfiles.

Logic for parsing and emailing dotfiles as attachments handled in /dotfiles route of backend.

Resulting email to hello@fig.io after script is run:

<img width="733" alt="Screen Shot 2021-09-10 at 11 39 49 AM" src="https://user-images.githubusercontent.com/10150898/132901900-132384af-5a03-4ba1-92e6-2601e06ac1dd.png">

User is also CC'd on the email.

See: https://github.com/withfig/core-backend/pull/13