### PR TITLE
Rename figterm binaries on install

### DIFF
--- a/shell/pre.sh
+++ b/shell/pre.sh
@@ -36,7 +36,9 @@ if ([[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]]) \
       FIG_TERM_NAME="${FIG_SHELL} (figterm)"
       FIG_SHELL_PATH="${HOME}/.fig/bin/$(basename "${FIG_SHELL}") (figterm)"
 
-      cp -p ~/.fig/bin/figterm "${FIG_SHELL_PATH}"
+      # Only copy figterm binary if it doesn't already exist
+      [[ -f "${FIG_SHELL_PATH}"]] || cp -p ~/.fig/bin/figterm "${FIG_SHELL_PATH}"
+
       # Get initial text.
       INITIAL_TEXT=""
       if [[ -z "${BASH}" || "${BASH_VERSINFO[0]}" -gt "3" ]]; then

--- a/tools/install_and_upgrade.sh
+++ b/tools/install_and_upgrade.sh
@@ -83,6 +83,12 @@ install_fig() {
   mkdir -p ~/.fig/{bin,zle}
   mkdir -p ~/.fig/user/{aliases,apps,autocomplete,aliases}
 
+  # rename figterm binaries to mirror supported shell
+  # copy binaries on install to avoid issues with file permissions at runtime
+  cp -p "${FIGCLI}"/.fig/bin/figterm "${FIGCLI}"/.fig/bin/zsh\ (figterm)
+  cp -p "${FIGCLI}"/.fig/bin/figterm "${FIGCLI}"/.fig/bin/bash\ (figterm)
+  cp -p "${FIGCLI}"/.fig/bin/figterm "${FIGCLI}"/.fig/bin/fish\ (figterm)
+
   if [[ ! -f ~/.fig/settings.json ]]; then
     echo "{}" > ~/.fig/settings.json
   fi


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix
**What is the current behavior? (You can also link to an open issue here)**
We currently copy `figterm` binary at runtime
**What is the new behavior (if this is a feature change)?**
Copy (and rename) on install
**Additional info:**
This solves issues related to permissioning