### PR TITLE
Fix right prompt issues

### DIFF
--- a/shell/post.zsh
+++ b/shell/post.zsh
@@ -46,16 +46,6 @@ fig_preexec() {
   fig_osc PreExec
 }
 
-fig_wrap_prompt() {
-  # This function expands the prompt if necessary. If not, it sets it
-  # as is.
-  if [[ "${1: -1}" == '%' ]]; then
-    echo "%{$START_PROMPT%}$1{$END_PROMPT%}"
-  else
-    echo "%{$START_PROMPT%}$1%{$END_PROMPT%}"
-  fi
-}
-
 fig_precmd() {
   local LAST_STATUS=$?
   __fig bg:prompt $$ $TTY &!

--- a/shell/post.zsh
+++ b/shell/post.zsh
@@ -66,12 +66,24 @@ fig_precmd() {
   FIG_USER_PS1="$PS1"
   FIG_USER_PS2="$PS2"
   FIG_USER_PS3="$PS3"
-  FIG_USER_RPS1="$RPS1"
+  [[ -v RPS1 ]] && FIG_USER_RPS1="$RPS1"
+  [[ -v RPROMPT ]] && FIG_USER_RPS1="$RPROMPT"
 
   PS1="%{$START_PROMPT%}$PS1%{$END_PROMPT$NEW_CMD%}"
   PS2="%{$START_PROMPT%}$PS2%{$END_PROMPT%}"
   PS3="%{$START_PROMPT%}$PS3%{$END_PROMPT$NEW_CMD%}"
-  RPS1="%{$START_PROMPT%}$RPS1%{$END_PROMPT%}"
+  # The af-magic theme adds a final # to expand. We need to paste without the #
+  # to avoid doubling up and mangling the prompt.
+  if [[ "$ZSH_THEME" == "af-magic" ]]; then
+    RPS1="%{$START_PROMPT%}$RPS1{$END_PROMPT%}"
+  else
+    # The right prompt can be set with either RPS1 or RPROMPT. These variables
+    # are not linked and can be set indepently. We need to copy the right prompt
+    # variable that is actually set.
+    [[ -v RPS1 ]] && RPS1="%{$START_PROMPT%}$RPS1%{$END_PROMPT%}"
+  fi
+  [[ -v RPROMPT ]] && RPS1="%{$START_PROMPT%}$RPROMPT%{$END_PROMPT%}"
+  
   FIG_HAS_SET_PROMPT=1
 
   # Temporary workaround for bug where istrip is activated when running brew install.

--- a/shell/post.zsh
+++ b/shell/post.zsh
@@ -9,7 +9,7 @@ else
 fi
 
 __fig() {
-  if [[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]] && command -v fig 2>&1 1>/dev/null; then
+    if [[ -d /Applications/Fig.app || -d ~/Applications/Fig.app ]] && command -v fig 2>&1 1>/dev/null; then
     fig "$@"
   fi
 }
@@ -23,11 +23,24 @@ fig_preexec() {
   __fig bg:exec $$ $TTY &!
 
   # Restore user defined prompt before executing.
-  PS1="$FIG_USER_PS1"
-  PS2="$FIG_USER_PS2"
-  PS3="$FIG_USER_PS3"
+  [[ -v PS1 ]] && PS1="$FIG_USER_PS1"
+  [[ -v PROMPT ]] && PROMPT="$FIG_USER_PROMPT"
+  [[ -v prompt ]] && prompt="$FIG_USER_prompt"
+
+  [[ -v PS2 ]] && PS2="$FIG_USER_PS2"
+  [[ -v PROMPT2 ]] && PROMPT2="$FIG_USER_PROMPT2"
+
+  [[ -v PS3 ]] && PS3="$FIG_USER_PS3"
+  [[ -v PROMPT3 ]] && PROMPT3="$FIG_USER_PROMPT3"
+
+  [[ -v PS4 ]] && PS4="$FIG_USER_PS4"
+  [[ -v PROMPT4 ]] && PROMPT4="$FIG_USER_PROMPT4"
+
   [[ -v RPS1 ]] && RPS1="$FIG_USER_RPS1"
   [[ -v RPROMPT ]] && RPROMPT="$FIG_USER_RPROMPT"
+
+  [[ -v RPS2 ]] && RPS2="$FIG_USER_RPS2"
+  [[ -v RPROMPT2 ]] && RPROMPT2="$FIG_USER_RPROMPT2"
 
   FIG_HAS_SET_PROMPT=0
   fig_osc PreExec
@@ -75,17 +88,49 @@ fig_precmd() {
 
   # Save user defined prompts.
   FIG_USER_PS1="$PS1"
+  FIG_USER_PROMPT="$PROMPT"
+  FIG_USER_prompt="$prompt"
+
   FIG_USER_PS2="$PS2"
+  FIG_USER_PROMPT2="$PROMPT2"
+
   FIG_USER_PS3="$PS3"
+  FIG_USER_PROMPT3="$PROMPT3"
+
+  FIG_USER_PS4="$PS4"
+  FIG_USER_PROMPT4="$PROMPT4"
+
   FIG_USER_RPS1="$RPS1"
   FIG_USER_RPROMPT="$RPROMPT"
 
-  PS1=$(fig_wrap_prompt $PS1)
-  PS2=$(fig_wrap_prompt $PS2)
-  PS3=$(fig_wrap_prompt $PS3)
-  [[ -v RPS1 ]] && RPS1=$(fig_wrap_prompt $RPS1)
-  [[ -v RPROMPT ]] && RPROMPT=$(fig_wrap_prompt $RPROMPT)
+  FIG_USER_RPS2="$RPS2"
+  FIG_USER_RPROMPT2="$RPROMPT2"
 
+  [[ -v PS1 ]] && PS1="%{$START_PROMPT%}$PS1%{$END_PROMPT$NEW_CMD%}"
+  [[ -v PROMPT ]] && PROMPT="%{$START_PROMPT%}$PROMPT%{$END_PROMPT$NEW_CMD%}"
+  [[ -v prompt ]] && prompt="%{$START_PROMPT%}$prompt%{$END_PROMPT$NEW_CMD%}"
+
+  [[ -v PS2 ]] && PS2="%{$START_PROMPT%}$PS2%{$END_PROMPT%}"
+  [[ -v PROMPT2 ]] && PROMPT2="%{$START_PROMPT%}$PROMPT2%{$END_PROMPT%}"
+
+  [[ -v PS3 ]] && PS3="%{$START_PROMPT%}$PS3%{$END_PROMPT$NEW_CMD%}"
+  [[ -v PROMPT3 ]] && PROMPT3="%{$START_PROMPT%}$PROMPT3%{$END_PROMPT$NEW_CMD%}"
+
+  [[ -v PS4 ]] && PS4="%{$START_PROMPT%}$PS4%{$END_PROMPT%}"
+  [[ -v PROMPT4 ]] && PROMPT4="%{$START_PROMPT%}$PROMPT4%{$END_PROMPT%}"
+
+  # The af-magic theme adds a final % to expand. We need to paste without the %
+  # to avoid doubling up and mangling the prompt.
+  if [[ "$ZSH_THEME" == "af-magic" ]]; then
+    RPS1="%{$START_PROMPT%}$RPS1{$END_PROMPT%}"
+  else
+    [[ -v RPS1 ]] && RPS1="%{$START_PROMPT%}$RPS1%{$END_PROMPT%}"
+  fi
+  [[ -v RPROMPT ]] && RPROMPT="%{$START_PROMPT%}$RPROMPT%{$END_PROMPT%}"
+
+  [[ -v RPS2 ]] && RPS2="%{$START_PROMPT%}$RPS2%{$END_PROMPT%}"
+  [[ -v RPROMPT2 ]] && RPROMPT2="%{$START_PROMPT%}$RPROMPT2%{$END_PROMPT%}"
+  
   FIG_HAS_SET_PROMPT=1
 
   # Temporary workaround for bug where istrip is activated when running brew install.

--- a/tools/doctor.sh
+++ b/tools/doctor.sh
@@ -132,12 +132,6 @@ if [[ $("$HOME"/.fig/bin/fig app:running) == 1 ]]; then
         fi
     fi
 
-    # Check for unsupported themes
-    # unsupported: af-magic
-    if grep -q "af-magic" <<<"$clean_config"; then
-        warn "af-magic is not a supported oh-my-zsh theme"
-    fi
-
     ########################
     # check fig diagnostic #
     ########################


### PR DESCRIPTION
The right prompt missing and af-magic incompatibility were actually 2 separate issues.

## Right prompt missing with Fig installed

The right prompt can be set in zsh by modifying either RPS1 or RPROMPT. These 2 variables do the exact thing but are not linked. If RPS1 is set, RPROMPT could be unset and vice versa. 

In our post.zsh, we copied RPS1 then added it back in. If the user used RPROMPT to set their right prompt, we were ignoring it so it would be missing entirely.

Changed post.zsh to copy whichever variable was set.

## Broker right prompt with af-magic theme

The af-magic right prompt is set:
```bash
RPS1='${return_code}'
(( $+functions[virtualenv_prompt_info] )) && RPS1+='$(virtualenv_prompt_info)'
RPS1+=' $my_gray%n@%m%{$reset_color%}%'
```

The 3rd line escapes the prompt with a final '%'. When we add back in RPS1, we expand it with another '%' which mangles the entire prompt.

Added an explicit check for af-magic so that RPS1 gets set as if it has already been expanded. Otherwise, set as usual.

Re: https://github.com/withfig/fig/issues/403 & https://github.com/withfig/fig/issues/311