### PR TITLE
Docs: Use 'GitHub' instead of 'Github'

### DIFF
--- a/tools/cli/contribute.sh
+++ b/tools/cli/contribute.sh
@@ -6,5 +6,5 @@
 #  Created by Matt Schrage on 1/7/21.
 #  Copyright © 2021 Matt Schrage. All rights reserved.
 
-echo "→ Opening Github repo..."
+echo "→ Opening GitHub repo..."
 open https://github.com/withfig/autocomplete

--- a/tools/cli/debug.sh
+++ b/tools/cli/debug.sh
@@ -56,7 +56,7 @@ case "$1" in
     sample $PID -f $OUT_FILE
     printf "\n\n\n-------\nFinished writing to $OUT_FILE\n"
     echo  "Please send this file to the Fig Team"
-    echo  "Or attach it to a Github issue (run 'fig issue')"
+    echo  "Or attach it to a GitHub issue (run 'fig issue')"
     ;;
   "terminal")
     clear
@@ -90,7 +90,7 @@ case "$1" in
     defaults read com.mschrage.fig.shared
 
     ;;
-  "unix-socket") 
+  "unix-socket")
     echo Listening on /tmp/fig.socket...
     echo "Note: You will need to restart Fig afterwards"
     rm /tmp/fig.socket && nc -Ulk /tmp/fig.socket

--- a/tools/cli/issue.sh
+++ b/tools/cli/issue.sh
@@ -6,5 +6,5 @@
 #  Created by Matt Schrage on 1/7/21.
 #  Copyright © 2021 Matt Schrage. All rights reserved.
 
-echo "→ Opening Github..."
+echo "→ Opening GitHub..."
 open https://github.com/withfig/fig/issues/new


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bulk replacement.

**What is the current behavior? (You can also link to an open issue here)**

**What is the new behavior (if this is a feature change)?**

**Additional info:**