### PR TITLE
Workaround for zim, z-sy-h, and substring history

### DIFF
--- a/shell/zle.zsh
+++ b/shell/zle.zsh
@@ -45,8 +45,18 @@ function fig_hide() {
 # Delete any widget, if it already exists
 add-zle-hook-widget line-pre-redraw fig_zsh_keybuffer
 
-# Update keybuffer on new line
-add-zle-hook-widget line-init fig_zsh_keybuffer
+# z-sy-h and zsh-substring-history conflict workaround
+# Wait for these plugins to wrap zle-line-init, create our
+# widget overwriting the original, then add-zle-hook-widget
+# as usual
+# See https://github.com/zsh-users/zsh-syntax-highlighting/issues/816
+if [[ $widgets[zle-line-init] == user:azhw:zle-line-init &&
+      $functions[add-zle-hook-widget] ]]; then
+    # Update keybuffer on new line
+    add-zle-hook-widget line-init fig_zsh_keybuffer
+else
+    zle -N zle-line-init fig_zsh_keybuffer
+fi
 
 # Hide when going through history (see also: histno logic in ShellHooksManager.updateKeybuffer)
 add-zle-hook-widget history-line-set fig_hide


### PR DESCRIPTION
This is a workaround for a bug in add-zle-hook-widget

1. fast-syntax-highlighting and zsh-history-substring-search make `$widgets[<hook>]` equal to `user:_zsh_highlight_widget_orig-s000-r<integer>-zle-<hook>`
2. which causes `[[ ${widgets[$hook]:-} != "user:azhw:$hook" ]]` in add-zle-hook-widget to evaluate to true
3. which in turn causes add-zle-hook-widget to add the same widget again to the list
4. so that the wrapped `zle-<hook>` widget now ends up calling itself.

This workaround ensures we don't call add-zle-hook-widget until these plugins have been sourced.

More info on add-zle-hook-widget bug: https://www.zsh.org/mla/workers/2021/msg01310.html

Fix: https://github.com/withfig/fig/issues/94