### PR TITLE
Get list of specs from remote repo

### DIFF
--- a/tools/cli/list.sh
+++ b/tools/cli/list.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 
-ls ~/.fig/autocomplete | grep -v README | cut -d '.' -f 1
+while IFS= read -ra line; do 
+    IFS=\":. read -ra file <<<"${line[@]}"
+    echo "${file[4]}"
+done <<<"$(curl \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/withfig/autocomplete/contents/src | grep "name")"


### PR DESCRIPTION
Specs are now served from skypack so looking at local specs is outdated

Using GitHub API to get list of directories in /src on master @ latest
Does not recursively list subdirectories

Mimics output of current fig list

Re: https://linear.app/fig/issue/ENG-1682/update-fig-list-for-skypack