### PR TITLE
Write tmp files to non-global temporary folder to avoid collisions

### DIFF
--- a/tools/install_integrations.sh
+++ b/tools/install_integrations.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+TMP_DIR=${TMPDIR:-'/tmp/'}
+
 error() {
   echo "Error: $@" >&2
   exit 1
@@ -42,7 +44,7 @@ fig_prepend() {
   # Don't prepend to files that don't exist to avoid creating file and
   # changing shell behavior.
   if [ -f "$2" ] && ! grep -q "source ~/.fig/$1" "$2"; then
-    echo "$(fig_source $1 "Please make sure this block is at the start of this file.")" | cat - "$2" > "/tmp/fig_prepend" && cat "/tmp/fig_prepend" > "$2"
+    echo "$(fig_source $1 "Please make sure this block is at the start of this file.")" | cat - "$2" > "/${TMP_DIR}/fig_prepend" && cat "/${TMP_DIR}/fig_prepend" > "$2"
   fi
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix
**What is the current behavior? (You can also link to an open issue here)**
If Fig is installed from another User account on the same machine, the install script will fail.
**What is the new behavior (if this is a feature change)?**
Resolves collisions by writing files to `$TMPDIR` which is unique across accounts.
**Additional info:**