### PR TITLE
List all themes in settings app

### DIFF
--- a/tools/all-settings.json
+++ b/tools/all-settings.json
@@ -21,7 +21,19 @@
     "title": "Theme",
     "description": "Change Fig's theme",
     "type": "single_select",
-    "options": ["dark", "light"],
+    "options": [
+      "dark",
+      "light",
+      "cobalt",
+      "cobalt2",
+      "dracula",
+      "github-dark",
+      "gruvbox",
+      "nightowl",
+      "nord",
+      "poimandres",
+      "the-unnamed"
+    ],
     "default": "dark",
     "category": "Appearance"
   },


### PR DESCRIPTION
Adds all themes to all-settings.json so they appear in the settings app dropdown

Fix: https://linear.app/fig/issue/ENG-1696/only-light-dark-theme-showing-in-fig-settings-app-withfigfig-491