### PR TITLE
fix fish shell enviroment variables

### DIFF
--- a/shell/post.fish
+++ b/shell/post.fish
@@ -22,11 +22,11 @@ if [ -t 1 ] && [ -z "$FIG_ENV_VAR" ] || [ -n "$TMUX" ]
   # Check for prompts or onboarding.
   if [ -s ~/.fig/tools/prompts.sh ]
     bash ~/.fig/tools/prompts.sh
-    export FIG_CHECKED_PROMPTS=1
+    set -gx FIG_CHECKED_PROMPTS 1
   end
 
-  export TTY=(tty)
-  export FIG_ENV_VAR=1
+  set -gx TTY tty
+  set -gx FIG_ENV_VAR 1
 end
 
 if [ -z "$FIG_SHELL_VAR" ]

--- a/shell/pre.fish
+++ b/shell/pre.fish
@@ -9,9 +9,9 @@ if [ -d /Applications/Fig.app -o -d ~/Applications/Fig.app ] \
   # explicitly set for VSCode and Hyper. This variable is inherited when
   # new ttys are created using tmux and must be explictly overwritten.
   if [ -z "$TERM_SESSION_ID" ] || [ -n "$TMUX" ] || [ "$TERM_PROGRAM" = vscode ]
-    export TERM_SESSION_ID=(uuidgen)
+    set -gx TERM_SESSION_ID uuidgen
   end
-  export FIG_INTEGRATION_VERSION=4
+  set -gx FIG_INTEGRATION_VERSION 4
 
   if command -v figterm 1>/dev/null 2>/dev/null
     if [ -z "$FIG_TERM" ] || [ -z "$FIG_TERM_TMUX" -a -n "$TMUX" ]


### PR DESCRIPTION
This small fixes for initial setup Fish shell.

Now integration with Fish doesn't work ([screenshot](https://cln.sh/HVW8AJ))

Replacing "export" with "set -gx" fix this bug  ([screenshot](https://cln.sh/Ht22M1))

Additional info: Fish shell documentation https://fishshell.com/docs/current/language.html#variables-export